### PR TITLE
fix: packages backup included pkgs removed by purge

### DIFF
--- a/terbr
+++ b/terbr
@@ -55,8 +55,9 @@ function list_packages () {
       installed+=(${line##* install })
     else
       removed+=(${line##* remove })
+      removed+=(${line##* purge })
     fi
-  done < <(grep -E ' install | remove ' ${TERBR_HISTFILE})
+  done < <(grep -E ' install | remove | purge ' ${TERBR_HISTFILE})
 
   # For every removed pkg, if it's also in installed pkgs
   # remove it from installed pkgs


### PR DESCRIPTION
if packages removes using command `apt purge pkgName`, it will remain included in installed list despite being removed.